### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,34 +7,34 @@
 #######################################
 
 WiFiMQTTManager	KEYWORD1
-wm  KEYWORD1
-client  KEYWORD1
-_espClient  KEYWORD1
+wm	KEYWORD1
+client	KEYWORD1
+_espClient	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-resetPin    KEYWORD2
-setup   KEYWORD2
-loop    KEYWORD2
-clientId    KEYWORD2
-deviceId    KEYWORD2
-subscribeTo KEYWORD2
-formatFS    KEYWORD2
-lastMsg KEYWORD2
-_setupSpiffs    KEYWORD2
-_checkButton    KEYWORD2
-_reconnect  KEYWORD2
-_mqtt_server    KEYWORD2
-_mqtt_port  KEYWORD2
-_mqtt_username  KEYWORD2
-_mqtt_password  KEYWORD2
-_ledPin KEYWORD2
-_LED_BUILTIN    KEYWORD2
-_lastMsg    KEYWORD2
-_lastMsg    KEYWORD2
-_value  KEYWORD2
-_shouldSaveConfig   KEYWORD2
+resetPin	KEYWORD2
+setup	KEYWORD2
+loop	KEYWORD2
+clientId	KEYWORD2
+deviceId	KEYWORD2
+subscribeTo	KEYWORD2
+formatFS	KEYWORD2
+lastMsg	KEYWORD2
+_setupSpiffs	KEYWORD2
+_checkButton	KEYWORD2
+_reconnect	KEYWORD2
+_mqtt_server	KEYWORD2
+_mqtt_port	KEYWORD2
+_mqtt_username	KEYWORD2
+_mqtt_password	KEYWORD2
+_ledPin	KEYWORD2
+_LED_BUILTIN	KEYWORD2
+_lastMsg	KEYWORD2
+_lastMsg	KEYWORD2
+_value	KEYWORD2
+_shouldSaveConfig	KEYWORD2
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab, the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords